### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ Inside functional components, you can use `useBazaar` which automatically calls
 ### purchaseProduct(productId: string): Promise&lt;PurchaseResult&gt;
 Purchase a product, bazaar starts payment flow automatically.
 
-### consumeProduct(purchaseToken: string): Promise&lt;void&gt;
-If your product is consumable, you can call `consumeProduct` whenever you see fit. To
-consume, you need to provide purchaseToken from a previous `purchaseProduct` call result.
+### consumePurchase(purchaseToken: string): Promise&lt;void&gt;
+If your product is consumable, you can call `consumePurchase` whenever you see fit. To
+consume, you need to provide purchaseToken from a previous `consumePurchase` call result.
 
 ### subscribeProduct(productId: string): Promise&lt;PurchaseResult&gt;
 Subscribe to a product, bazaar starts payment flow automatically.


### PR DESCRIPTION
سلام
مطابق [خط `132`](https://github.com/cafebazaar/react-native-poolakey/blob/main/android/src/main/java/com/cafebazaarreactnativepoolakey/ReactNativePoolakeyModule.kt#L132) فایل `android\src\main\java\com\cafebazaarreactnativepoolakey\ReactNativePoolakeyModule.kt` نام تابع `consumePurchase` هست  ولی در مخزن و هم در [کافه بازار](https://developers.cafebazaar.ir/fa/guidelines/in-app-billing/implementation/react-native#Implementation) عبارت `consumeProduct` نوشته شده، عبارت را اصلاح کردم.

به نظر میاد  به علت اختلاف نام این تابع در این کتابخانه با نام تابع مشابه در [کتابخانه پولکی](https://github.com/cafebazaar/Poolakey) در  مستندات از چشم افتاده.

