### PR TITLE
Fix warning(new NativeEventEmitter()...)

### DIFF
--- a/android/src/main/java/com/cafebazaarreactnativepoolakey/ReactNativePoolakeyModule.kt
+++ b/android/src/main/java/com/cafebazaarreactnativepoolakey/ReactNativePoolakeyModule.kt
@@ -227,7 +227,17 @@ class ReactNativePoolakeyModule(
       }
     }
   }
+  
+  @ReactMethod
+  fun addListener(type: String?) {
+      // Keep: Required for RN built in Event Emitter Calls.
+  }
 
+  @ReactMethod
+  fun removeListeners(type: String?) {
+      // Keep: Required for RN built in Event Emitter Calls.
+  }
+  
   override fun onNewIntent(intent: Intent?) {
     // no need to handle this method
   }


### PR DESCRIPTION
Fix warning: new NativeEventEmitter()` was called with a non-null argument without the required `addListener` method.